### PR TITLE
Fix for Node LTS compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ install:
 
 script:
   - make
-  - if [ -n "$TEST" ]; then make test; fi
+  - make test_generator
+  - if [ -n "$TEST" ]; then make test_jsjsref; fi
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,23 @@
 language: node_js
+node_js: "lts/carbon"
 sudo: required
 dist: trusty
 
 env:
   global:
-    - OCAML_VERSION=4.04.2
+    - OCAML_VERSION=4.04
+    - OPAM_SWITCH=4.04.2
     - OPAMYES=true
     - UBUNTU_TRUSTY=1
 
 matrix:
   include:
     - os: linux
-      node_js: "10"
       env: DEPLOY=true
     - os: linux
-      node_js: "10"
       env: TEST=true
-    #- os: osx
-    #  node_js: "10"
   allow_failures:
     - os: linux
-      node_js: "10"
       env: TEST=true
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ init: .merlin
 	opam install -y jsjsref --deps-only
 	@# Temporary hack until opam can install test dependencies only
 	opam install alcotest
+	npm install
 	@echo
 	@echo 'You now need to execute: eval `opam config env`'
 
@@ -24,7 +25,6 @@ mljsref: generator # (requires the ppx)
 
 # Test Stages
 test_init: test/data/test262
-	npm install
 
 test: test_generator test_jsjsref
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,82 @@
 
 An (unofficial) ECMAScript Reference Interpreter and Double-debugger.
 
-## Installation
-To install:
+## Building
+### Dependencies
+The minimum system dependencies are:
+* **OCaml** (any working version, correct version will be installed via OPAM)
+* **OPAM ~1.2.2** (2.0.0 may also work)
+* **Nodejs >=8** (Carbon LTS release) and the corresponding **npm**
+* **Make**
+* **Git**
+
+Optional dependencies:
+* rsync, for uploading builds to deployment servers
+* xdg-open, for shortcut Make targets for opening built pages
+* Perl / PHP interpreters, for single-use scripts within the tools directory
+* Python, for the runtests distributed test execution tool in tools/runtests
+
+### Initialising the build environment
+To install other dependencies:
 ```sh
 make init
 eval `opam config env`
+```
+
+If you intend to run the test262 test suite:
+```
+make test_init
+```
+
+### Building
+To build all default targets:
+```
 make
 ```
 
-You can run the tool locally by opening the ~driver.html~ page.
+You can run the tool locally by opening the `driver.html` page. (`make open` is
+a shortcut for this).
 
 To test jsjsref using test262:
 ```sh
-make test_init
 make test
 ```
+### Toplevel Make Targets
+* Initialisation targets
+  * `init`: Initialises the build environment by obtaining the correct OCaml
+    version, and dependencies via opam and npm.
+  * `test_init`: Initialises the test262 submodule and any other dependencies
+    required for testing the interpreter.
+  * `.merlin`: Builds the `.merlin` IDE configuration file. (Automatically built
+    by `init`).
+* Build Targets
+  * `all` (default): Builds the `generator`, `mljsref`, `jsjsref` targets.
+  * `generator`: Builds the `generator` subdirectory.
+  * `jsjsref`: Builds the jsref interpreter using the ml-to-js generator.
+  * `mljsref`: Builds the jsref interpreter using the standard OCaml compiler.
+* Testing targets
+  * `test`: Tests the generator and jsjsref.
+  * `test_generator`: Runs the generator testsuite. (See generator directory for
+  detail.
+  * `test_jsjsref`: Tests jsjsref against the test262 test suite.
+* Documentation targets
+  * `doc`: Builds jsref documentation using ocamldoc with a custom 'esdocgen'
+    output driver.
+  * `esdocgen`: Builds the custom ocamldoc output driver.
+* Distribution targets
+  * `dist`: Performs a build of jsjsref and documentation and places all files
+    required for distribution into the `dist` directory.
+  * `publish`: Publishes the `dist` directory to the inria-gforge server (requires
+    authentication).
+  * `publish-github`: Publishes the `dist` directory to the `gh-pages` branch.
+    This is executed on successful CI build.
+* Browser shortcuts
+  * `open`: Builds jsjsref and opens the `driver.html` page in your browser when
+    done.
+  * `opendoc`: Builds the jsref documentation and opens the documentation index in
+    your browser when done.
+* `clean`: Cleans all built files for the entire project, recursively.
+
 ## Testing
 To select subsets of tests to run you can use the `-g` flag with the
 pattern to grep for in the test name. Each test262 test case's path is
@@ -27,8 +88,9 @@ run test cases for the if statement, you could use:
 Latest version of jsjsref & debugger is automatically published at:
 https://jscert.github.io/jsexplain/branch/master/driver.html
 
+<!-- NOTE: this service is currently broken.
 mljsref results are tested online and results published to:
-https://psvg.doc.ic.ac.uk/ci/jscert-testing/
+https://psvg.doc.ic.ac.uk/ci/jscert-testing/ -->
 
 ## Architecture
 The source code for the interpreter is primarily written in a subset of

--- a/generator/tests/Compare.js
+++ b/generator/tests/Compare.js
@@ -1,2 +1,10 @@
-const _compare_generic = require('util').isDeepStrictEqual;
+const __jsexplain_assert = require('assert');
+const _compare_generic = function (val1, val2) {
+  try {
+    __jsexplain_assert.deepStrictEqual(val1, val2);
+  } catch (_) {
+    return false;
+  }
+  return true;
+};
 const _compare_stack = _compare_generic;

--- a/generator/tests/lib/mocha.js
+++ b/generator/tests/lib/mocha.js
@@ -20,4 +20,4 @@ it = function(string, callback) {
 Mocha.assert_unit = x => {
   Mocha.assert_struct_eq(x, {}, x + " is not unit ({}).")
 }
-Mocha.assert_failwith = (f, e, m) => Mocha.throws(f, Error(e), m);
+Mocha.assert_failwith = (f, e, m) => Mocha.throws(f, RegExp(e), m);

--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "readlink": "^1.0.1",
     "through2-filter": "^2.0.0"
   },
-  "engines": { "node": ">=8.11" }
+  "engines": { "node": ">=8" }
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,7 @@
     "readlink": "^1.0.1",
     "through2-filter": "^2.0.0"
   },
-  "engines": { "node": ">=8" }
+  "engines": {
+    "node": ">=8"
+  }
 }

--- a/test/helpers/test262.js
+++ b/test/helpers/test262.js
@@ -19,20 +19,9 @@ const filter = require('through2-filter');
 fs.readlinkSync = require('readlink').sync; // a non-broken readlink...
 const test262parser = require('test262-parser');
 const supportedFeatures = require('./supported-features.js');
+const baseReporter = require('mocha').reporters.Base;
 
 const testConstructors = [];
-
-// Shorten failure output
-const Base = require('mocha').reporters.Base;
-const oldReporterList = Base.list;
-Base.list = failures => {
-  if (!process.env.CI || process.env.CI === 'false') {
-    oldReporterList(failures);
-  } else {
-    console.log(Base.color('fail', 'Failure stack traces are suppressed in the CI environment.'));
-  }
-};
-
 const testDataPath = path.join(__dirname, '..', 'data');
 const test262path = fs.readlinkSync(path.join(testDataPath, 'test262'));
 const localHarnessPath = path.join(testDataPath, 'harness');
@@ -66,7 +55,8 @@ setImmediate(() => {
                   usedFeatures.delete(feature);
                 }
                 if (usedFeatures.size > 0) {
-                  console.log(Base.color('pending', 'Test skipped due to missing features: %s'), Array.from(usedFeatures).join(', '));
+                  console.log(baseReporter.color('pending', 'Test skipped due to missing features: %s'),
+                    Array.from(usedFeatures).join(', '));
                   this.skip();
                 }
               })

--- a/test/interpreter.js
+++ b/test/interpreter.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const fs = require('fs');
-const assert = require('assert').strict;
+const assert = require('assert');
 // tripwire module is no longer maintained
 //const tripwire = require('tripwire');
 
@@ -31,7 +31,7 @@ before(function(done) {
   fs.readFile(__dirname + '/data/test_prelude.js', (err, data) => {
     if (err) throw err;
     prelude = jsref.JsInterpreter.run_javascript(parse(data));
-    assert.doesNotThrow(() => testResultForException(prelude, undefined), "Prelude execution threw!");
+    testResultForException(prelude, undefined);
     done();
   });
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require('assert').strict;
+const assert = require('assert');
 const util = require('util');
 
 var esprima = require('esprima');
@@ -143,7 +143,7 @@ function typecheckAST(ast) {
     if (i >= 0) {
       var polyTypeName = type.substring(i+1);
       var polyTypeConstr = getType(polyTypeName);
-      assert(typeof polyTypeConstr === 'function');
+      assert.strictEqual(typeof polyTypeConstr, 'function');
       var instance = polyTypeConstr(type.substring(0, i));
       instance._typeName = polyTypeName;
       return instance;
@@ -163,13 +163,13 @@ function typecheckAST(ast) {
   var typecheck = function(type, value) {
     var t = getType(type);
     if (isBaseType(t)) {
-      assert(t === typeof value, errorMsg(value, "was expected to have type of "+t));
+      assert.strictEqual(typeof value, t, errorMsg(value, "was expected to have type of "+t));
     } else if (Array.isArray(t)) {
-      assert(Array.isArray(value));
+      assert(Array.isArray(value), errorMsg(value, "was expected to be an array"));
       t.forEach((type, index) => typecheck(type, value[index]));
     } else {
-      assert(value.type === t._typeName, errorMsg(value, "was expected to have type of " + t._typeName));
-      assert.notEqual(value.tag, "_typeName");
+      assert.strictEqual(t._typeName, value.type, errorMsg(value, "was expected to have type of " + t._typeName));
+      assert.notEqual("_typeName", value.tag);
       assert(t.hasOwnProperty(value.tag), value.tag + " is a not a valid constructor of " + t._typeName);
 
       // Test each field defined in the type constructor
@@ -199,7 +199,7 @@ a()};`;
     var ast = esprimaToAST.esprimaToAST(prog, source);
 
     var sourceBody = /{([^]*)}/.exec(source)[1];
-    assert.equal(sourceBody, ast.elements.head.body.source);
+    assert.strictEqual(sourceBody, ast.elements.head.body.source);
 
   });
 
@@ -212,7 +212,7 @@ a()};`;
     it("Correctly parses that `" + test.source + "` is " + (test.strict ? " " : "not ") + "strict mode code?", function() {
       var est = esprima.parse(test.source, {loc: true, range: true});
       var ast = esprimaToAST.esprimaToAST(est, test.source);
-      assert.equal(test.strict, ast.strictness);
+      assert.strictEqual(test.strict, ast.strictness);
     });
   });
 
@@ -248,7 +248,7 @@ a()};`;
       var index = 0;
       while (listElem.tag === "::") {
         if (isFunction(listElem.head)) {
-          assert.equal(test.strict[index], getFunctionStrictness(listElem.head));
+          assert.strictEqual(test.strict[index], getFunctionStrictness(listElem.head));
           index++;
         }
         listElem = listElem.tail;


### PR DESCRIPTION
* Fix Compare.js in the generator testsuite to work with Node <9
* Travis CI should now use lts/carbon (8.x) for testing.

Fixes #29